### PR TITLE
Fix several issues with the GOp mission UI

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIMission_LWCustomMission.uc
@@ -2,9 +2,9 @@
 //  FILE:    UIMission_LWCustomMission.uc
 //  AUTHOR:  Amineri / Pavonis Interactive
 //  PURPOSE: Provides controls viewing a generic mission, including multiple of the same type in a region
-//			 This is used for initiating infiltration/investigation of a mission site 
+//			 This is used for initiating infiltration/investigation of a mission site
 //			 Launching a mission after investigation has begun is handled in UIMission_LWLaunchDelayedMission
-//--------------------------------------------------------------------------------------- 
+//---------------------------------------------------------------------------------------
 
 // WOTC TODO - This file is probably better split up into separate versions for particular mission sub-types like
 // they are in WOTC. These sub-classes involve many override functions called from the base UIMission and may need
@@ -153,15 +153,15 @@ simulated function string GetSFX()
 		case eMissionUI_GuerrillaOps:
 			return "GeoscapeFanfares_GuerillaOps";
 		case eMissionUI_SupplyRaid:
-			return "Geoscape_Supply_Raid_Popup";  
+			return "Geoscape_Supply_Raid_Popup";
 		case eMissionUI_LandedUFO:
-			return "Geoscape_UFO_Landed";  
+			return "Geoscape_UFO_Landed";
 		case eMissionUI_GoldenPath:
 		case eMissionUI_GPIntel:
-			return "GeoscapeFanfares_GoldenPath"; 
+			return "GeoscapeFanfares_GoldenPath";
 		case eMissionUI_AlienFacility:
         case eMissionUI_Rendezvous:
-			return "GeoscapeFanfares_AlienFacility"; 
+			return "GeoscapeFanfares_AlienFacility";
 		case eMissionUI_Council:
 			return "Geoscape_NewResistOpsMissions";
 		case eMissionUI_Retaliation:
@@ -197,9 +197,10 @@ simulated function BuildScreen()
 	super.BuildScreen();
 
 	// Add the LW-specific mission info: squad size, concealment type, evac mode, etc.
-	class'UIUtilities_LW'.static.BuildMissionInfoPanel(self, MissionRef);
+	class'UIUtilities_LW'.static.BuildMissionInfoPanel(self, MissionRef, false);
 
-	BuildConfirmPanel();
+	// This call does nothing, but is left in for comparison to the original UIMission_GOps class.
+	//BuildConfirmPanel();
 }
 
 // Called when screen is removed from Stack
@@ -226,10 +227,10 @@ simulated function BuildMissionPanel()
 			BuildGuerrillaOpsMissionPanel();
 			break;
 		case eMissionUI_SupplyRaid:
-			BuildSupplyRaidMissionPanel(); 
+			BuildSupplyRaidMissionPanel();
 			break;
 		case eMissionUI_LandedUFO:
-			BuildLandedUFOMissionPanel(); 
+			BuildLandedUFOMissionPanel();
 			break;
 		case eMissionUI_GoldenPath:
 			BuildGoldenPathMissionPanel();
@@ -266,10 +267,10 @@ simulated function BuildOptionsPanel()
 			BuildGuerrillaOpsOptionsPanel();
 			break;
 		case eMissionUI_SupplyRaid:
-			BuildSupplyRaidOptionsPanel(); 
+			BuildSupplyRaidOptionsPanel();
 			break;
 		case eMissionUI_LandedUFO:
-			BuildLandedUFOOptionsPanel(); 
+			BuildLandedUFOOptionsPanel();
 			break;
 		case eMissionUI_GoldenPath:
 			BuildGoldenPathOptionsPanel();
@@ -300,8 +301,8 @@ simulated function BuildOptionsPanel()
 
 simulated function AddIgnoreButton()
 {
-	//Button is controlled by flash and shows by default. Hide if need to. 
-	//local UIButton IgnoreButton; 
+	//Button is controlled by flash and shows by default. Hide if need to.
+	//local UIButton IgnoreButton;
 
 	IgnoreButton = Spawn(class'UIButton', LibraryPanel);
 	if(CanBackOut())
@@ -330,7 +331,8 @@ simulated function AddIgnoreButton()
 
 simulated function OnButtonSizeRealized()
 {
-	// Override - do nothing
+	// Override - do nothing. The base version will alter the position of the
+	// confirm button, so an empty version is necessary to suppress that.
 }
 
 simulated function UpdateData()
@@ -395,7 +397,7 @@ simulated function String GetObjectiveString()
 	ObjectiveString $= "\n";
 
 	AlienActivity = GetAlienActivity();
-	
+
 	if (AlienActivity != none)
 	{
 		ActivityTemplate = AlienActivity.GetMyTemplate();
@@ -489,7 +491,7 @@ simulated function BuildGuerrillaOpsMissionPanel()
 
 	if (MissionInfoText == none)
 	{
-		MissionInfoText = Spawn(class'UITextContainer', LibraryPanel);	
+		MissionInfoText = Spawn(class'UITextContainer', LibraryPanel);
 		MissionInfoText.bAnimateOnInit = false;
 		MissionInfoText.MCName = 'MissionInfoText_LW';
 		if (bHasDarkEvent)
@@ -504,7 +506,7 @@ simulated function BuildGuerrillaOpsMissionPanel()
 	if(AlienActivity != none)
 		MissionInfoText.SetHTMLText(class'UIUtilities_Text'.static.GetColoredText(AlienActivity.GetMissionDescriptionForActivity(), eUIState_Normal));
 	else
-		MissionInfoText.Hide();		
+		MissionInfoText.Hide();
 }
 
 simulated function UpdateGOpButtons()
@@ -543,7 +545,8 @@ simulated function BuildGuerrillaOpsOptionsPanel()
 	// ----------------------------------------------------------------------
 
 	// WOTC TODO Other mission types may be missing these
-	BuildConfirmPanel();
+	// BuildConfirmPanel does nothing, but left in for comparison with UIMission_GOps.
+	// BuildConfirmPanel();
 	AddIgnoreButton();
 	SetTimer(0.3, false, 'UpdateGOpButtons');
 }
@@ -554,7 +557,7 @@ simulated function BuildCouncilMissionPanel()
 {
 	LibraryPanel.MC.BeginFunctionOp("UpdateCouncilInfoBlade");
 	LibraryPanel.MC.QueueString(GetMissionImage());					// defined in UIMission
-	LibraryPanel.MC.QueueString("../AssetLibraries/ProtoImages/Proto_HeadFirebrand.tga"); 
+	LibraryPanel.MC.QueueString("../AssetLibraries/ProtoImages/Proto_HeadFirebrand.tga");
 	LibraryPanel.MC.QueueString("../AssetLibraries/TacticalIcons/Objective_VIPGood.tga");
 	LibraryPanel.MC.QueueString(class'UIMission_Council'.default.m_strImageGreeble);
 	LibraryPanel.MC.QueueString(GetRegion().GetMyTemplate().DisplayName);
@@ -682,7 +685,7 @@ simulated function BuildRetaliationOptionsPanel()
 
 	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationButtonBlade");
 	LibraryPanel.MC.QueueString(class'UIMission_Retaliation'.default.m_strRetaliationWarning);
-	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(class'UIMission_Retaliation'.default.m_strRetaliationDesc));	
+	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(class'UIMission_Retaliation'.default.m_strRetaliationDesc));
 	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
 	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
 	LibraryPanel.MC.QueueString("" /*LockedTitle*/);
@@ -725,7 +728,7 @@ simulated function BuildRendezvousOptionsPanel()
 
 	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationButtonBlade");
 	LibraryPanel.MC.QueueString(m_strUrgent);
-	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(m_strRendezvousDesc));	
+	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(m_strRendezvousDesc));
 	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
 	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
 	LibraryPanel.MC.QueueString("" /*LockedTitle*/);
@@ -769,7 +772,7 @@ simulated function BuildInvasionOptionsPanel()
 
 	LibraryPanel.MC.BeginFunctionOp("UpdateRetaliationButtonBlade");
 	LibraryPanel.MC.QueueString(m_strInvasionWarning);
-	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(m_strInvasionDesc));	
+	LibraryPanel.MC.QueueString(GetRegionLocalizedDesc(m_strInvasionDesc));
 	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericConfirm);
 	LibraryPanel.MC.QueueString(class'UIUtilities_Text'.default.m_strGenericCancel);
 	LibraryPanel.MC.QueueString("" /*LockedTitle*/);
@@ -821,7 +824,7 @@ simulated function BuildAlienFacilityMissionPanel()
 }
 
 simulated function bool CanTakeAlienFacilityMission()
-{	
+{
 	return GetRegion().HaveMadeContact();
 }
 
@@ -871,7 +874,7 @@ simulated function BuildAlienFacilityOptionsPanel()
 		Button1.OnClickedDelegate = OnLaunchClicked;
 		Button2.OnClickedDelegate = OnCancelClicked;
 	}
-	
+
 	Button1.SetBad(true);
 	Button2.SetBad(true);
 
@@ -922,7 +925,7 @@ simulated function BuildGoldenPathOptionsPanel()
 	{
 		LibraryPanel.MC.QueueString(m_strLocked);
 		LibraryPanel.MC.QueueString(class'UIMission_GoldenPath'.default.m_strLockedHelp);
-		
+
 		LibraryPanel.MC.QueueString(m_strOK); //OnCancelClicked
 	}
 	LibraryPanel.MC.EndOp();

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIUtilities_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIUtilities_LW.uc
@@ -291,11 +291,93 @@ static function string GetEvacTypeString (XComGameState_MissionSite MissionState
 	return "";
 }
 
-function static BuildMissionInfoPanel(UIScreen ParentScreen, StateObjectReference MissionRef)
+// Build the infiltration string for a mission - shows % infiltrated, time until 100% or
+// mission expiry, and a description of the current advent alertedness modifier.
+//
+// WOTC TODO This function was moved from UIMission_LWLaunchDelayedMission so the infiltration
+// info can be added to the mission brief panel. The various localized strings used here are
+// still declared in that class and could be moved here, but this panel is still a work in progress
+// and may change.
+function static string GetInfiltrationString(XComGameState_MissionSite MissionState, XComGameState_LWAlienActivity ActivityState, XComGameState_LWPersistentSquad InfiltratingSquad)
+{
+	local string InfiltrationString;
+	local XGParamTag ParamTag;
+	local float TotalSeconds_Mission, TotalSeconds_Infiltration;
+	local float TotalSeconds, TotalHours, TotalDays;
+	local bool bExpiringMission, bCanFullyInfiltrate, bMustLaunch;
+	local int AlertnessIndex, AlertModifier;
+
+	ParamTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
+	ParamTag.IntValue0 = int(InfiltratingSquad.CurrentInfiltration * 100.0);
+
+	bExpiringMission = MissionState.ExpirationDateTime.m_iYear < 2050;
+	bMustLaunch = ActivityState != none && ActivityState.bMustLaunch;
+
+	if(bMustLaunch)
+	{
+		InfiltrationString = `XEXPAND.ExpandString(class'UIMission_LWLaunchDelayedMission'.default.m_strInfiltrationStatusNonExpiring);
+	}
+	else if(bExpiringMission)
+	{
+		//determine if can fully infiltrate before mission expires
+		TotalSeconds_Mission = ActivityState.SecondsRemainingCurrentMission();
+		TotalSeconds_Infiltration = InfiltratingSquad.GetSecondsRemainingToFullInfiltration();
+
+		bCanFullyInfiltrate = (TotalSeconds_Infiltration < TotalSeconds_Mission) && (InfiltratingSquad.CurrentInfiltration < 1.0);
+		if(bCanFullyInfiltrate)
+		{
+			TotalSeconds = TotalSeconds_Infiltration;
+		}
+		else
+		{
+			TotalSeconds = TotalSeconds_Mission;
+		}
+		TotalHours = int(TotalSeconds / 3600.0) % 24;
+		TotalDays = TotalSeconds / 86400.0;
+		ParamTag.IntValue1 = int(TotalDays);
+		ParamTag.IntValue2 = int(TotalHours);
+
+		if(bCanFullyInfiltrate && InfiltratingSquad.CurrentInfiltration < 1.0)
+			InfiltrationString = `XEXPAND.ExpandString(class'UIMission_LWLaunchDelayedMission'.default.m_strInfiltrationStatusExpiring);
+		else
+			InfiltrationString = `XEXPAND.ExpandString(class'UIMission_LWLaunchDelayedMission'.default.m_strInfiltrationStatusMissionEnding);
+	}
+	else // mission does not expire
+	{
+		//ID 619 - allow non-expiring missions to show remaining time until 100% infiltration will be reached
+		if (InfiltratingSquad.CurrentInfiltration < 1.0)
+		{
+			TotalSeconds = InfiltratingSquad.GetSecondsRemainingToFullInfiltration();
+			TotalHours = int(TotalSeconds / 3600.0) % 24;
+			TotalDays = TotalSeconds / 86400.0;
+			ParamTag.IntValue1 = int(TotalDays);
+			ParamTag.IntValue2 = int(TotalHours);
+			InfiltrationString = `XEXPAND.ExpandString(class'UIMission_LWLaunchDelayedMission'.default.m_strInfiltrationStatusExpiring);
+		}
+		else
+		{
+			InfiltrationString = `XEXPAND.ExpandString(class'UIMission_LWLaunchDelayedMission'.default.m_strInfiltrationStatusNonExpiring);
+		}
+	}
+
+	InfiltrationString $= "\n";
+
+	ParamTag = XGParamTag(`XEXPANDCONTEXT.FindTag("XGParam"));
+	AlertModifier = InfiltratingSquad.GetAlertnessModifierForCurrentInfiltration(,, AlertnessIndex);
+	ParamTag.StrValue0 = class'UIMission_LWLaunchDelayedMission'.default.m_strAlertnessModifierDescriptions[AlertnessIndex];
+	if (false) // for debugging only !
+		ParamTag.StrValue0 $= " (" $ AlertModifier $ ")";
+	InfiltrationString $= `XEXPAND.ExpandString(class'UIMission_LWLaunchDelayedMission'.default.m_strInfiltrationConsequence);
+
+	return InfiltrationString;
+}
+
+function static BuildMissionInfoPanel(UIScreen ParentScreen, StateObjectReference MissionRef, bool IsInfiltrating)
 {
 	local XComGameState_LWSquadManager SquadMgr;
 	local XComGameState_MissionSite MissionState;
 	local XComGameState_LWAlienActivity ActivityState;
+	local XComGameState_LWPersistentSquad InfiltratingSquad;
 	local UIPanel MissionExpiryPanel;
 	local UIBGBox MissionExpiryBG;
 	local UIX2PanelHeader MissionExpiryTitle;
@@ -303,7 +385,7 @@ function static BuildMissionInfoPanel(UIScreen ParentScreen, StateObjectReferenc
 	local X2CharacterTemplate FacelessTemplate;
 	local String MissionTime;
 	local float TotalMissionHours;
-	local string MissionInfoTimer, MissionInfo1, MissionInfo2, HeaderStr;
+	local string MissionInfoTimer, MissionInfo1, MissionInfo2, HeaderStr, InfilInfo;
 	local int EvacFlareTimer;
 
 	SquadMgr = `LWSQUADMGR;
@@ -318,10 +400,16 @@ function static BuildMissionInfoPanel(UIScreen ParentScreen, StateObjectReferenc
 	else
 		TotalMissionHours = class'X2StrategyGameRulesetDataStructures'.static.DifferenceInSeconds(MissionState.ExpirationDateTime, class'XComGameState_GeoscapeEntity'.static.GetCurrentTime()) / 3600.0;
 	MissionInfoTimer = "";
+
+	InfiltratingSquad = SquadMgr.GetSquadOnMission(MissionRef);
+	if (IsInfiltrating)
+	{
+		InfilInfo = GetInfiltrationString(MissionState, ActivityState, InfiltratingSquad) $ "\n";
+	}
 	MissionInfo1 = "<font size=\"16\">";
 	MissionInfo1 $= GetMissionTypeString (MissionRef) @ default.m_strBullet $ " ";
 
-	if (SquadMgr.GetSquadOnMission(MissionRef) != none)
+	if (InfiltratingSquad != none)
 	{
 		EvacFlareTimer = GetCurrentEvacDelay(SquadMgr.GetSquadOnMission(MissionRef),ActivityState);
 	}
@@ -370,20 +458,32 @@ function static BuildMissionInfoPanel(UIScreen ParentScreen, StateObjectReferenc
 		MissionExpiryPanel.Remove();
 	}
 	MissionExpiryPanel = ParentScreen.Spawn(class'UIPanel', ParentScreen);
-	MissionExpiryPanel.InitPanel('ExpiryPanel').SetPosition(725, 800);
+	MissionExpiryPanel.InitPanel('ExpiryPanel').SetPosition(725, 180);
 	MissionExpiryBG = ParentScreen.Spawn(class'UIBGBox', MissionExpiryPanel);
 	MissionExpiryBG.LibID = class'UIUtilities_Controls'.const.MC_X2Background;
-	MissionExpiryBG.InitBG('ExpiryBG', 0, 0, 470, 130);
+
+	// Adjust the panel size depending on whether or not we are infiltrating - the infiltation
+	// status string needs some extra lines in a large-ish font.
+	MissionExpiryBG.InitBG('ExpiryBG', 0, 0, 470, IsInfiltrating ? 200 : 130);
 	MissionExpiryTitle = ParentScreen.Spawn(class'UIX2PanelHeader', MissionExpiryPanel);
 
 	if (TotalMissionHours >= 0.0 && TotalMissionHours <= 10000.0 && MissionState.ExpirationDateTime.m_iYear < 2100)
-		MissionInfoTimer = class'UISquadSelect_InfiltrationPanel'.default.strMissionTimeTitle @ MissionTime $ "\n";
+	{
+		if (ActivityState != none && ActivityState.bMustLaunch)
+		{
+			MissionInfoTimer = class'UIMission_LWLaunchDelayedMission'.default.m_strMustLaunchMission $ "\n";
+		}
+		else
+		{
+			MissionInfoTimer = class'UISquadSelect_InfiltrationPanel'.default.strMissionTimeTitle @ MissionTime $ "\n";
+		}
+	}
 
 	HeaderStr = class'UIMissionIntro'.default.m_strMissionTitle;
 	HeaderStr -= ":";
 	MissionExpiryTitle.InitPanelHeader('MissionExpiryTitle',
 										HeaderStr,
-										MissionInfoTimer $ MissionInfo1 $ "\n" $ MissionInfo2 $ "</font>");
+										InfilInfo $ MissionInfoTimer $ MissionInfo1 $ "\n" $ MissionInfo2 $ "</font>");
 	MissionExpiryTitle.SetHeaderWidth(MissionExpiryBG.Width - 20);
 	MissionExpiryTitle.SetPosition(MissionExpiryBG.X + 10, MissionExpiryBG.Y + 10);
 	MissionExpiryPanel.Show();


### PR DESCRIPTION
Fixes #16 and #17

The interaction between the base `UIMission` and mission-specific
subtypes changed in WotC and the LW version needed some updates. This
change goes through the `UIMission_GOps` class from WOTC and updates the
LW version to be roughly equivalent.

In particular the class needs an empty `OnButtonSizeRealized` function
to avoid the base version moving the confirm button around (#16), and
the screen building needs to invoke the base class `BuildScreen` to
properly set up the chosen and sitrep UI elements (among others) so
they will be hidden when appropriate (#17).

It's probably better to split this file up into separate versions for
different mission types, but I didn't do that here. Non-GOp missions
may still have bugs because of this. Dark Event display may need
updating too.